### PR TITLE
[WHD-108] It Is Time, not its time.

### DIFF
--- a/index.html
+++ b/index.html
@@ -128,7 +128,7 @@
       <p class="coming-soon">COMING SOON</p>
       <p class="text"><strong>2023 marked the deadliest year on record for humanitarian workers and 2024 could be even worse.</strong> Despite 75 years of international law to protect civilians and aid workers, violations continue. Civilians and humanitarian workers are paying the price with their lives, while those responsible escape justice.</p>
       <p class="text">On World Humanitarian Day, August 19, join our call to end these violations and the impunity that allows them.</p>
-      <p class="act-for-humanity">ITS TIME FOR THOSE IN POWER TO <em>#ACTFORHUMANITY.</em></p>
+      <p class="act-for-humanity">IT'S TIME FOR THOSE IN POWER TO <em>#ACTFORHUMANITY.</em></p>
     </div>
 
     <footer>


### PR DESCRIPTION
The original text had a typo, which I noticed when I opened the Chinese translation file and the grammar check highlighted it. Fixed here.